### PR TITLE
Update Cassandra version from 1.2.10 to 1.2.11

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Docker setup for Apache Cassandra
 
 This repository contains a set of scripts and configuration files to run a Cassandra cluster
 from [Docker](https://www.docker.io/) containers. The current version of this repository is
-configured to create a Cassandra 1.2.10 image and cluster.
+configured to create a Cassandra 1.2.11 image and cluster.
 
 Cassandra nodes are created with their own IP address and configured hostname:
 
@@ -42,15 +42,15 @@ The latest version is on GitHub at https://github.com/jpetazzo/pipework.
 
 ### 3. Create a Docker image for Cassandra
 
-To create a Cassandra 1.2.10 image and tag it, run:
+To create a Cassandra 1.2.11 image and tag it, run:
 
-    $ sudo docker build -t cassandra:1.2.10 install/
+    $ sudo docker build -t cassandra:1.2.11 install/
 
 You should then see it appear in your list of Docker images:
 
     $ sudo docker images
     REPOSITORY          TAG                 ID                  CREATED              SIZE
-    cassandra           1.2.10              b9ba84a33bb5        About a minute ago   12.29 kB (virtual 404.7 MB)
+    cassandra           1.2.11              b9ba84a33bb5        About a minute ago   12.29 kB (virtual 404.7 MB)
 
 ### 4. Start a cluster
 
@@ -60,9 +60,9 @@ Run `sudo docker ps` to list your Cassandra nodes:
 
     $ sudo docker ps
     ID                  IMAGE               COMMAND                CREATED             STATUS              PORTS
-    99d67692f535        cassandra:1.2.10    /usr/bin/start-cassa   10 minutes ago      Up 10 minutes       49332->9160         
-    fe7e2b13cb9e        cassandra:1.2.10    /usr/bin/start-cassa   10 minutes ago      Up 10 minutes       49331->9160         
-    f21da380b00c        cassandra:1.2.10    /usr/bin/start-cassa   10 minutes ago      Up 10 minutes       49330->9160  
+    99d67692f535        cassandra:1.2.11    /usr/bin/start-cassa   10 minutes ago      Up 10 minutes       49332->9160         
+    fe7e2b13cb9e        cassandra:1.2.11    /usr/bin/start-cassa   10 minutes ago      Up 10 minutes       49331->9160         
+    f21da380b00c        cassandra:1.2.11    /usr/bin/start-cassa   10 minutes ago      Up 10 minutes       49330->9160  
 
 ### 5. Connect to your cluster
 

--- a/client.sh
+++ b/client.sh
@@ -7,7 +7,7 @@ if [[ -z $1 ]]; then
 fi
 
 BRIDGE=br1
-VERSION=1.2.10
+VERSION=1.2.11
 
 # We want to start the client containers from cass254, with decreasing IDs
 id=254

--- a/install/Dockerfile
+++ b/install/Dockerfile
@@ -6,7 +6,7 @@ RUN apt-get install -y wget openjdk-6-jre dnsmasq-base
 
 # Install Cassandra
 ADD bin/install-cassandra /usr/bin/install-cassandra
-RUN install-cassandra 1.2.10
+RUN install-cassandra 1.2.11
 
 # Install start scripts and hosts file
 ADD bin/pipework /usr/bin/

--- a/start-cluster.sh
+++ b/start-cluster.sh
@@ -5,7 +5,7 @@ if [[ -z $1 ]]; then
 	exit 1
 fi
 NODES=$1
-VERSION=1.2.10
+VERSION=1.2.11
 BRIDGE=br1
 
 for id in $(seq 1 $NODES); do

--- a/stop-cluster.sh
+++ b/stop-cluster.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-IMAGE=cassandra:1.2.10
+IMAGE=cassandra:1.2.11
 
 if sudo docker ps | grep $IMAGE >/dev/null; then
 	cids=$(sudo docker ps | grep $IMAGE | awk '{ print $1 }')


### PR DESCRIPTION
doesnt appear 1.2.10 is in the mirrors anymore. Updating to 1.2.11
