### PR TITLE
update apt cache

### DIFF
--- a/install/Dockerfile.template
+++ b/install/Dockerfile.template
@@ -2,6 +2,7 @@ FROM ubuntu:precise
 MAINTAINER Nicolas Favre-Felix <n.favrefelix@gmail.com>
 
 # Install dependencies
+RUN apt-get -y update
 RUN DEBIAN_FRONTEND=noninteractive apt-get install -y --force-yes software-properties-common python-software-properties
 RUN add-apt-repository -y ppa:webupd8team/java
 RUN apt-get -y update


### PR DESCRIPTION
Depending on the image state we could need to update apt cache otherwise the first "apt-get install" fails
