### PR TITLE
-dns is deprecated in docker run 0.9.1

### DIFF
--- a/start-cluster.sh
+++ b/start-cluster.sh
@@ -22,7 +22,7 @@ for id in $(seq 1 $NODES); do
 	else
 		ports=""
 	fi
-	cid=$(sudo docker run -d -dns 127.0.0.1 -h $hostname $ports -t cassandra:$VERSION /usr/bin/start-cassandra)
+	cid=$(sudo docker run -d --dns 127.0.0.1 -h $hostname $ports -t cassandra:$VERSION /usr/bin/start-cassandra)
 
 	# Add network interface
 	sleep 1


### PR DESCRIPTION
Docker version 0.9.1, build 3600720
When I launch ./start-cluster.sh I get this message :

``` bash
Warning: '-dns' is deprecated, it will be replaced by '--dns' soon. See usage.
```
