### PR TITLE
Add support for Cassandra 2.1.0-beta2 and upcoming 2.1* releases

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+install/Dockerfile

--- a/install/bin/install-cassandra
+++ b/install/bin/install-cassandra
@@ -1,9 +1,10 @@
 #!/bin/bash
 
 VERSION=$1
+VERSION_DIR=$(sed 's/-.*//g' <<< $VERSION)
 
 # Download and extract
-wget http://archive.apache.org/dist/cassandra/$VERSION/apache-cassandra-$VERSION-bin.tar.gz
+wget http://archive.apache.org/dist/cassandra/$VERSION_DIR/apache-cassandra-$VERSION-bin.tar.gz
 tar -xvzf apache-cassandra-$VERSION-bin.tar.gz
 rm -f apache-cassandra-$VERSION-bin.tar.gz
 mv apache-cassandra-$VERSION /root/

--- a/install/bin/start-cassandra
+++ b/install/bin/start-cassandra
@@ -9,7 +9,9 @@ ENV=/root/apache-cassandra/conf/cassandra-env.sh
 
 # Change the listen address so that we can communicate with other nodes
 sed -i -e "s/^listen_address.*/listen_address: $IP/"   $CONFIG
-sed -i -e "s/^rpc_address.*/rpc_address: 0.0.0.0/"   $CONFIG
+sed -i -e 's/^rpc_address.*/rpc_address: 0.0.0.0/'   $CONFIG
+# Start from cassandra 2.1.0 broadcast_rpc_address needs to be defined if rpc_address = 0.0.0.0
+sed -i -e 's/^# broadcast_rpc_address.*/broadcast_rpc_address: 1.2.3.4/'   $CONFIG
 
 # wait 10 seconds instead of 30
 export JVM_OPTS="-Dcassandra.ring_delay_ms=10000"


### PR DESCRIPTION
- Allow to download beta versions of Cassandra
- Add quick support for new Cassandra 2.1 broadcast_rpc_address config var that conflict with rpc_address when set to 0.0.0.0
