### PR TITLE
Update install-cassandra - set PasswordAuthenticator

### DIFF
--- a/install/bin/install-cassandra
+++ b/install/bin/install-cassandra
@@ -16,4 +16,6 @@ sed -i -e "s/^# num_tokens.*/num_tokens: 256/"      $CONFIG
 sed -i -e "s/^listen_address.*/listen_address: /"   $CONFIG
 sed -i -e "s/^rpc_address.*/rpc_address: 0.0.0.0/"  $CONFIG
 sed -i -e 's/seeds: "127.0.0.1"/seeds: "cass1"/g' $CONFIG
+sed -i -e 's/authenticator: AllowAllAuthenticator/authenticator: PasswordAuthenticator/g' $CONFIG
+sed -i -e 's/authorizer: AllowAllAuthorizer/authorizer: CassandraAuthorizer/g' $CONFIG
 sed -i -e "s/Xss180k/Xss300k/g" $ENV


### PR DESCRIPTION
Note that to create users and grant permissions, you need to have PasswordAuthenticator and CassandraAuthorizer enabled. I was using it to set up Datomic on Cassandra cluster. 
(you can read about what I was doing with it here: http://juliangamble.com/blog/2014/06/15/installing-cassandra-on-os-x-mavericks-using-docker-on-vagrant/)
